### PR TITLE
User-editable Comments, HTML Emails and Admin Quick-delete

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -74,6 +74,9 @@ rophako:
     # key. Do NOT use that one, it was just an example. Make your own!
     secret_key: 'for the love of Arceus, change this key!'
 
+    # How long the session key should last for (in days).
+    session_lifetime: 30
+
     # Password strength: number of iterations for bcrypt password.
     bcrypt_iterations: 12
 
@@ -141,10 +144,15 @@ rophako:
 
   comment:
     time_format: *DATE_FORMAT
+
     # We use Gravatar for comments if the user provides an e-mail address.
     # Specify the URL to a fallback image to use in case they don't have
     # a gravatar.
-    default_avatar:
+    default_avatar: ""
+
+    # The grace period window that users are allowed to modify or delete their
+    # own comments (in hours)
+    edit_period: 2
 
   wiki:
     default_page: Main Page

--- a/rophako/app.py
+++ b/rophako/app.py
@@ -80,6 +80,10 @@ Emoticons.load_theme()
 def before_request():
     """Called before all requests. Initialize global template variables."""
 
+    # Session lifetime.
+    app.permanent_session_lifetime = datetime.timedelta(days=Config.security.session_lifetime)
+    session.permanent = True
+
     # Default template vars.
     g.info = rophako.utils.default_vars()
 

--- a/rophako/modules/comment/templates/comment/index.inc.html
+++ b/rophako/modules/comment/templates/comment/index.inc.html
@@ -25,12 +25,18 @@ There {% if comments|length == 1 %}is{% else %}are{% endif %}
 		{{ comment["formatted_message"]|safe }}
 
 		<div class="clear">
-			{% if session["login"] %}
-				[IP: {{ comment["ip"] }}
+			{% if session["login"] or comment["editable"] %}
+				[
+				{% if session["login"] %}
+					IP: {{ comment["ip"] }}
+				{% else %}
+					<em class="comment-editable">You recently posted this</em>
+				{% endif %}
 				|
 				<a href="{{ url_for('comment.edit', thread=thread, cid=comment['id'], url=url) }}">Edit</a>
 				|
-				<a href="{{ url_for('comment.delete', thread=thread, cid=comment['id'], url=url) }}" onclick="return window.confirm('Are you sure?')">Delete</a>]
+				<a href="{{ url_for('comment.delete', thread=thread, cid=comment['id'], url=url) }}" onclick="return window.confirm('Are you sure?')">Delete</a>
+				]
 			{% endif %}
 		</div>
 	</div><p>

--- a/rophako/modules/comment/templates/comment/preview.html
+++ b/rophako/modules/comment/templates/comment/preview.html
@@ -8,7 +8,7 @@ This is a preview of what your comment is going to look like once posted.<p>
 
 <div class="comment">
 	<div class="comment-author">
-		{% if contact %}
+		{% if gravatar %}
 			<img src="{{ gravatar }}" alt="Avatar" width="96" height="96">
 		{% else %}
 			<img src="/static/avatars/default.png" alt="guest" width="96" height="96">

--- a/rophako/modules/contact/__init__.py
+++ b/rophako/modules/contact/__init__.py
@@ -48,12 +48,12 @@ def send():
         subject="Contact Form on {}: {}".format(Config.site.site_name, subject),
         message="""A visitor to {site_name} has sent you a message!
 
-IP Address: {ip}
-User Agent: {ua}
-Referrer: {referer}
-Name: {name}
-E-mail: {email}
-Subject: {subject}
+* IP Address: `{ip}`
+* User Agent: `{ua}`
+* Referrer: <{referer}>
+* Name: {name}
+* E-mail: <{email}>
+* Subject: {subject}
 
 {message}""".format(
             site_name=Config.site.site_name,

--- a/rophako/www/email.inc.html
+++ b/rophako/www/email.inc.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="x-apple-disable-message-reformatting"><!-- Disable auto-scale in iOS 10 Mail -->
+	<title>{{ title }}</title>
+</head>
+<body width="100%" bgcolor="#FFFFFF" color="#000000" style="margin: 0; mso-line-height-rule: exactly;">
+
+<center>
+	<table width="90%" cellspacing="0" cellpadding="8" style="border: 1px solid #000000">
+		<tr>
+			<td align="left" valign="top" bgcolor="#C0C0C0">
+				<font face="Helvetica,Arial,Verdana-sans-serif" size="6" color="#000000">
+					<b>{{ header }}</b>
+				</font>
+			</td>
+		</tr>
+		<tr>
+			<td align="left" valign="top" bgcolor="#FEFEFE">
+				<font face="Helvetica,Arial,Verdana-sans-serif" size="3" color="#000000">
+					{{ message|safe }}
+				</font>
+			</td>
+		</tr>
+		<tr>
+			<td align="left" valign="top" bgcolor="#C0C0C0">
+				<font face="Helvetica,Arial,Verdana-sans-serif" size="3" color="#000000">
+					{% if footer %}
+						{{ footer|safe }}
+					{% else %}
+						This e-mail was automatically generated; do not reply to it.
+					{% endif %}
+				</font>
+			</td>
+		</tr>
+	</table>
+</center>
+
+</body>
+</html>


### PR DESCRIPTION
This makes various quality-of-life enhancements on the commenting system of Rophako:

## User-editable Comments

Users can now be given a grace period where they're allowed to edit (or delete) their own comments added to the site.

Session cookies are made long-lived (30 day window), and all commenting users are given a random "Comment Deletion Token" that is saved in their session (one is generated only when it doesn't already exist).

All comments created by that session will have the deletion token saved with their data as the `token` parameter. (Old comments won't have tokens, this is OK).

If a user views their comments within 2 hours of posting it (the default grace window), and their session Comment Deletion Token matches the stored comment's, they are shown the "Edit" and "Delete" links along with a small notice that they posted the comment recently. (The notice takes the place of the admin's view where it shows the IP address of the commenter).

The "Edit" and "Delete" functionality on a comment can be used **if** the tokens of the end user match and the comment is still new. Site admins can always edit or delete comments as before.

## HTML Emails

All e-mails sent from the Rophako CMS will now have HTML and plain text variants.

The HTML email template is named `email.inc.html`, so site owners can change the layout by creating their own template.

E-mail bodies are now treated as Markdown text: the HTML version of the e-mail renders the Markdown into HTML, and the plain text version uses the text as-is.

This allows for clickable links in all e-mail clients, and rendering of Markdown text in comments.

## Quick Delete

To help delete spam comments as quickly as possible, the *admin copy* of the notification e-mail for new comments will include a Quick Delete link. This is a one-click deletion of the comment that doesn't require the user to be logged in.

How it works: I use `itsdangerous` to sign the comment details using the site's secret key (Flask uses `itsdangerous` in the same way for its session cookies). This makes the "Quick Delete Token" hard to predict and impossible to forge by end users.

## Misc Fixes

This also fixes the Comment Preview page for logged-in users. Previously, their name would show as "Anonymous" and the default avatar was shown. Now it uses their real name and user avatar.